### PR TITLE
Fix game initialization order

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,6 @@
         INTERRUPTS.keep[1] = JSON.parse(JSON.stringify(INTERRUPTS.data[1]));
         INTERRUPTS.keep[2] = JSON.parse(JSON.stringify(INTERRUPTS.data[2]));
     </script>
-    <script src="scripts/pre.js"></script>
     <script src="scripts/Entangled.js"></script>
     <script src="scripts/BoardData.js"></script>
     <script src="scripts/CopyBuffer.js"></script>
@@ -476,6 +475,7 @@
     <script src="scripts/Tile.js"></script>
     <script src="scripts/RedWire.js"></script>
     <script src="scripts/SoundData.js"></script>
+    <script src="scripts/pre.js"></script>
     <script>
       if (typeof doInterrupt !== 'undefined') {
         document.getElementById("overback").style.display = "none";


### PR DESCRIPTION
## Summary
- load `pre.js` after all other scripts in `index.html`

This ensures initialization code runs only after all classes are defined.

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_686b77fe0e088325bd03c9ea03ca0c9f