### PR TITLE
Move pre.js to start of scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,6 +413,7 @@
         INTERRUPTS.keep[1] = JSON.parse(JSON.stringify(INTERRUPTS.data[1]));
         INTERRUPTS.keep[2] = JSON.parse(JSON.stringify(INTERRUPTS.data[2]));
     </script>
+    <script src="scripts/pre.js"></script>
     <script src="scripts/Entangled.js"></script>
     <script src="scripts/BoardData.js"></script>
     <script src="scripts/CopyBuffer.js"></script>
@@ -475,7 +476,7 @@
     <script src="scripts/TutControl.js"></script>
     <script src="scripts/Tile.js"></script>
     <script src="scripts/RedWire.js"></script>
-    <script src="scripts/pre.js"></script>
+
     <script>
       if (typeof doInterrupt !== 'undefined') {
         document.getElementById("overback").style.display = "none";


### PR DESCRIPTION
## Summary
- reorder scripts so pre.js is loaded first

## Testing
- `node -e "try{require('playwright'); console.log('playwright available')}catch(e){console.error('no playwright');}"`


------
https://chatgpt.com/codex/tasks/task_b_686b8878dbec83259a4bddc5354eb11b