### PR TITLE
Translate Awards label in Achievements.js

### DIFF
--- a/scripts/Achievements.js
+++ b/scripts/Achievements.js
@@ -66,7 +66,7 @@ class Achievements {
       (r.fillStyle = "black"),
       (r.textAlign = "left"),
       (r.textBaseline = "middle"),
-      r.fillText("Awards:", 16.9 * a, 1.3 * a),
+      r.fillText("アワード:", 16.9 * a, 1.3 * a),
       r.beginPath(),
       (r.lineWidth = 1.5),
       (r.lineStyle = "#888"),


### PR DESCRIPTION
## Summary
- translate the label for the awards section in `Achievements.js` to Japanese

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_686db4c3d5b88325bfd6b023a1f97cdf